### PR TITLE
Fix type of family_size variable in unix_list.c

### DIFF
--- a/chap01/unix_list.c
+++ b/chap01/unix_list.c
@@ -51,7 +51,7 @@ int main() {
             printf("%s\t", family == AF_INET ? "IPv4" : "IPv6");
 
             char ap[100];
-            const int family_size = family == AF_INET ?
+            const socklen_t family_size = family == AF_INET ?
                 sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
             getnameinfo(address->ifa_addr,
                     family_size, ap, sizeof(ap), 0, 0, NI_NUMERICHOST);


### PR DESCRIPTION
Not a major problem, but the actual type of the family_size variable passed as an argument to getnameinfo, should be socklen_t instead of int (see the salen parameter in the getnameinfo function signature).